### PR TITLE
[fix] Fix build warnings on Ubuntu 21.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-build
-build-coverage
-doxygen
-.vscode
-doc/_build
+/build*
+/doxygen
+/.vscode
+/doc/_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ setup_internal_gmock_and_gtest()
 enable_cxx_11()
 
 ######################################################
+# disable one warning on new gcc to avoid somes from 1.7.0 version of google mock.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wno-deprecated-copy HAS_NO_DEPRECATED_COPY)
+if (HAS_NO_DEPRECATED_COPY)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
+endif (HAS_NO_DEPRECATED_COPY)
+
+######################################################
 set(ENABLE_COVERAGE OFF CACHE BOOL "Enable coverage profiling.")
 if (ENABLE_COVERAGE)
 	enable_gcc_coverage()

--- a/extern-deps/googletest-release-1.10.0/CMakeLists.txt
+++ b/extern-deps/googletest-release-1.10.0/CMakeLists.txt
@@ -29,6 +29,14 @@ include(GNUInstallDirs)
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
 option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" OFF)
 
+######################################################
+# disable one warning on new gcc to avoid somes from 1.7.0 version of google mock.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wno-deprecated-copy HAS_NO_DEPRECATED_COPY)
+if (HAS_NO_DEPRECATED_COPY)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
+endif (HAS_NO_DEPRECATED_COPY)
+
 if(BUILD_GMOCK)
   add_subdirectory( googlemock )
 else()

--- a/extern-deps/googletest-release-1.10.0/googletest/src/gtest-death-test.cc
+++ b/extern-deps/googletest-release-1.10.0/googletest/src/gtest-death-test.cc
@@ -1296,8 +1296,8 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
 static bool StackGrowsDown() {
-  int dummy;
-  bool result;
+  int dummy = 0;
+  bool result = false;
   StackLowerThanAddress(&dummy, &result);
   return result;
 }


### PR DESCRIPTION
Fix the build issues on Ubuntu 21.10 reported by new Clang & Gcc compilers.

Also update the .gitignore to better filter the build directories.