### PR TITLE
[fix] Fix memory leaks reported by ASAN

### DIFF
--- a/src/base/network/LibfabricConnection.hpp
+++ b/src/base/network/LibfabricConnection.hpp
@@ -147,6 +147,7 @@ class LibfabricConnection
 		void onConnInit(LibfabricClientRequest & request);
 		bool checkAuth(LibfabricMessageHeader & header, uint64_t clientId, int id);
 		void pollAllCqInCache(void);
+		void pollAllPendingAction(void);
 	private:
 		/** Pointer to the libfabric domain to be used to establish the connection. **/
 		LibfabricDomain * lfDomain;
@@ -203,6 +204,8 @@ class LibfabricConnection
 		bool disableReceive;
 		/** Buffer to store batch readed completion queue entries **/
 		std::list<fi_cq_msg_entry> cqEntries;
+		/** Number of pending send. **/
+		int pendingAction;
 };
 
 /****************************************************/

--- a/src/base/network/LibfabricDomain.cpp
+++ b/src/base/network/LibfabricDomain.cpp
@@ -40,8 +40,7 @@ LibfabricDomain::LibfabricDomain(const std::string & serverIp, const std::string
 	this->msgBufferSize = 1024*1024;
 
 	//allocate fi
-	struct fi_info *hints;
-	hints = fi_allocinfo();
+	struct fi_info *hints = fi_allocinfo();
 	if (!hints) {
 		printf("fi_allocinfo failed\n");
 		exit(1);
@@ -65,6 +64,9 @@ LibfabricDomain::LibfabricDomain(const std::string & serverIp, const std::string
 	//printf("MSG: %d\n", this->fi->caps & FI_MSG);
 	//printf("RMA: %d\n", this->fi->caps & FI_RMA);
 	//printf("RMA_PMEM: %d\n", this->fi->caps & FI_RMA_PMEM);
+
+	//free
+	fi_freeinfo(hints);
 
 	//display
 	//IOC_INFO_ARG("NET: %1").arg(fi->fabric_attr->prov_name).end();

--- a/src/base/network/tests/TestLibfabricConnection.cpp
+++ b/src/base/network/tests/TestLibfabricConnection.cpp
@@ -346,6 +346,11 @@ TEST(TestLibfabricConnection, rdma)
 		ASSERT_EQ(1, ((char*)ptrServer1)[i]) << i;
 		ASSERT_EQ(1, ((char*)ptrServer2)[i]) << i;
 	}
+
+	//free
+	free(ptrClient);
+	free(ptrServer1);
+	free(ptrServer2);
 }
 
 /****************************************************/
@@ -429,6 +434,11 @@ TEST(TestLibfabricConnection, rdmav)
 		ASSERT_EQ(1, ((char*)ptrServer1)[i]) << i;
 		ASSERT_EQ(1, ((char*)ptrServer2)[i]) << i;
 	}
+
+	//free mem
+	free(ptrClient);
+	free(ptrServer1);
+	free(ptrServer2);
 }
 
 /****************************************************/
@@ -532,7 +542,7 @@ TEST(TestLibfabricConnection, message_auth_not_ok)
 		connection.postReceives(IOC_POST_RECEIVE_READ, 2);
 		connection.joinServer();
 		//on error
-		connection.setOnBadAuth([&gotError](){
+		connection.setOnBadAuth([&gotError, &connection](){
 			gotError = true;
 			return LF_WAIT_LOOP_UNBLOCK;
 		});

--- a/src/base/network/tests/TestLibfabricDomain.cpp
+++ b/src/base/network/tests/TestLibfabricDomain.cpp
@@ -52,4 +52,8 @@ TEST(TestLibfaricDomain, register_mem_and_getmr)
 	//check
 	EXPECT_NE(mr1, mr2);
 	EXPECT_NE(mr1->mem_desc, mr2->mem_desc);
+
+	//deregister
+	domain.unregisterSegment(buffer1, 1024);
+	domain.unregisterSegment(buffer2, 1024);
 }

--- a/src/server/core/Config.cpp
+++ b/src/server/core/Config.cpp
@@ -78,7 +78,7 @@ static error_t parseOptions(int key, char *arg, struct argp_state *state) {
 		case 'c': config->consistencyCheck = false; break;
 		case 'p': config->activePolling = true; break;
 		case 'a': config->clientAuth = false; break;
-		case 'm': config->meroRcFile = strdup(arg); break;
+		case 'm': config->meroRcFile = arg; break;
 		case 'v':
 			if (arg == nullptr)
 				DAQ::Debug::enableAll();

--- a/src/server/core/tests/TestObject.cpp
+++ b/src/server/core/tests/TestObject.cpp
@@ -291,6 +291,9 @@ TEST(TestObject, buildIovec_no_offset)
 	iovec * res = Object::buildIovec(segList, 0, 512);
 	EXPECT_EQ((void*)buffer, (void*)(res[0].iov_base));
 	EXPECT_EQ(512, res[0].iov_len);
+
+	//cleara
+	delete [] res;
 }
 
 /****************************************************/
@@ -308,4 +311,7 @@ TEST(TestObject, buildIovec_offset)
 	iovec * res = Object::buildIovec(segList, 128, 512);
 	EXPECT_EQ((void*)(buffer+128), (void*)(res[0].iov_base));
 	EXPECT_EQ(512-128, res[0].iov_len);
+
+	//clear
+	delete [] res;
 }


### PR DESCRIPTION
Fix all important memory leaks reported by ASAN, most are related to the unit test special way to run.

There is still some global allocation on first init in libevent and libfabric but it is a uniq allocation when calling the lib the first time.