### PR TITLE
[worker] Define what is a basic task (#3)

### DIFF
--- a/src/server/worker/Task.hpp
+++ b/src/server/worker/Task.hpp
@@ -40,7 +40,7 @@ class Task
 		inline void performAll(void);
 		inline bool isImmediate(void) const;
 		inline void markAsImmediate(void);
-		inline bool getStage(void) const;
+		inline TaskStage getStage(void) const;
 	protected:
 		/** Prepage stage to compute the buffer addresses for the run stage. */
 		virtual void runPrepare(void) = 0;
@@ -153,7 +153,7 @@ void Task::markAsImmediate(void)
 
 /****************************************************/
 /** Return the current stage of the task. **/
-bool Task::getStage(void) const
+TaskStage Task::getStage(void) const
 {
 	return this->nextStage;
 };

--- a/src/server/worker/Task.hpp
+++ b/src/server/worker/Task.hpp
@@ -1,0 +1,163 @@
+/*****************************************************
+*  PROJECT  : IO Catcher                             *
+*  LICENSE  : Apache 2.0                             *
+*  COPYRIGHT: 2022 Sebastien Valat                   *
+*****************************************************/
+#ifndef IOC_TASK_HPP
+#define IOC_TASK_HPP
+
+/****************************************************/
+#include <cassert>
+#include "base/common/Debug.hpp"
+
+/****************************************************/
+namespace IOC
+{
+
+/****************************************************/
+enum TaskStage
+{
+	STAGE_PREPARE,
+	STAGE_ACTION,
+	STAGE_POST,
+	STAGE_FINISHED
+};
+
+/****************************************************/
+/**
+ * Define what is a task to be deferred to a worker thread. A task has two
+ * actions. A run action to be called in the worker thread and a post-action
+ * to be called on the main network handling thread when the task has been
+ * performed.
+**/
+class Task
+{
+	public:
+		inline Task(void);
+		virtual inline ~Task(void);
+		inline bool runNextStage(void);
+		inline bool runNextStage(TaskStage expectedStage);
+		inline void performAll(void);
+		inline bool isImmediate(void) const;
+		inline void markAsImmediate(void);
+		inline bool getStage(void) const;
+	protected:
+		/** Prepage stage to compute the buffer addresses for the run stage. */
+		virtual void runPrepare(void) = 0;
+		/** Perform the given action in the worker thread. */
+		virtual void runAction(void) = 0;
+		/** 
+		 * To be called in the network handling thread after the action has 
+		 * been performed by the worker. 
+		**/
+		virtual void runPostAction(void) = 0;
+	private:
+		/** Define if the task need to be runned immediately of not. **/
+		bool immediate;
+		/** Next stage to perform. **/
+		TaskStage nextStage;
+};
+
+/****************************************************/
+/** Default constructor. **/
+Task::Task(void)
+{
+	this->immediate = false;
+	this->nextStage = STAGE_PREPARE;
+}
+
+/****************************************************/
+/**
+ * Destructor, only checks that we ran everything.
+**/
+Task::~Task(void)
+{
+	assert(this->nextStage == STAGE_FINISHED || this->nextStage == STAGE_PREPARE);
+};
+
+/****************************************************/
+/** Run next stage. **/
+bool Task::runNextStage(void)
+{
+	//var
+	bool res = false;
+
+	//apply
+	switch(this->nextStage) {
+		case STAGE_PREPARE:
+			this->runPrepare();
+			this->nextStage = STAGE_ACTION;
+			break;
+		case STAGE_ACTION:
+			this->runAction();
+			this->nextStage = STAGE_POST;
+			break;
+		case STAGE_POST:
+			this->runPostAction();
+			this->nextStage = STAGE_FINISHED;
+			res = true;
+			break;
+		default:
+			IOC_FATAL("Invalid stage to run !");
+			break;
+	}
+
+	//ret
+	return res;
+}
+
+/****************************************************/
+/** Run next stage and check we are at the expected one. **/
+bool Task::runNextStage(TaskStage expectedStage)
+{
+	//check
+	assumeArg(this->nextStage == expectedStage, "Invalid stage (%1), expected (%2)")
+		.arg(this->nextStage)
+		.arg(expectedStage)
+		.end();
+
+	//run
+	return this->runNextStage();
+}
+
+/****************************************************/
+/** Perform both actions in one go. **/
+void Task::performAll(void)
+{
+	while(this->runNextStage()) {};
+}
+
+/****************************************************/
+/** 
+ * Tell to the worker manager to run the task immediatly and not send it to a 
+ * worker thread.
+ * This is usefull to make the small task optimization not entering in
+ * thread queue communications and get a fast local execution.
+**/
+bool Task::isImmediate(void) const
+{
+	return this->immediate;
+};
+
+/****************************************************/
+/** 
+ * Tell to the worker manager to run the task immediatly and not send it to a 
+ * worker thread.
+ * This is usefull to make the small task optimization not entering in
+ * thread queue communications and get a fast local execution.
+**/
+void Task::markAsImmediate(void)
+{
+	this->immediate = true;
+};
+
+/****************************************************/
+/** Return the current stage of the task. **/
+bool Task::getStage(void) const
+{
+	return this->nextStage;
+};
+
+}
+
+#endif //IOC_TASK_HPP


### PR DESCRIPTION
### The added Task class

This PR introduce the concept of Task which is represented by a virtual class to be extended to provide the read/write/flush/cow deferred option to be executed in the worker threads.

A **task** should implement 3 stages:

1. The **prepare** stage run in the network handling main thread and can access the object structure to extract the buffer addresses to be used in the worker thread to run the deferred operations (read/write/memcpy). It can also trigger new memory allocations. As all those operations are done in the network handling thread it does not require mutexes at all.
2. The **run action** stage will be called in the worker thread to perform the deferred operation (read/write/memcpy). It should only use the resources attached to the task by the prepare action and never access the object structure.
3. The **post action** stage run again on the network handling main thread when the task has been terminated. It is used to terminate the operation, for example update the dirty states and send the final response to the client.

### Immediate

About the **immediate** option: we can decide that the task is too small to pay the cost of sending it to the worker thread. In this case we just call `this->markAsImmediate()` to tell to the worker system to run it immediately in the network handling thread instead of pushing in in the worker queue. This will in a first step be decided by the task itself in the **prepare** phase but we can extend by looking on a more advanced scenario with an intelligent scheduler looking on the number of pending such immediate tasks.

### Remark

I will currently consider that the response sending will be done in the **post action** phase. We can work a bit on the `LibfabricConnection` implementation to be able to send the response from the thread, adding locks or splitting the send and receive queues. Although I'm not sure it is so interesting to add this complexity.